### PR TITLE
DV-136 4o to 4o-mini

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -14,8 +14,7 @@ class Config:
     AWS_REGION = os.getenv("AWS_REGION")
     S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME")
 
-    # GPT_MODEL = "gpt-3.5-turbo"  # 테스트용. 프롬프팅 성능 테스트 후 gpt-4o로 변경하기
-    GPT_MODEL = "gpt-4o"
+    GPT_MODEL = "gpt-4o-mini"
     ANTHROPIC_MODEL = "claude-3-opus-20240229"
 
     SEED = 456  # 동일한 입력에 대해 일관된 결과를 생성


### PR DESCRIPTION
gpt-4o와 gpt-4o-mini가 처리할 수 있는 토큰 수가 똑같아서 비용절감을 위해 mini로 모델을 변경했습니다.
나중에 실서비스 지원 및 생성값 퀄리티 테스트할 때 다시 수정하면 될 것 같습니다.

  ```
GPT-4o와 GPT-4o Mini는 모두 128K 토큰의 컨텍스트 창을 지원하며, 요청당 최대 16K 출력 토큰을 생성할 수 있습니다. 
  UNITE
   따라서 두 모델의 토큰 수 용량에는 차이가 없습니다.
```